### PR TITLE
Fix If-Modified-Since Header bug

### DIFF
--- a/js/lastfm.js
+++ b/js/lastfm.js
@@ -274,7 +274,7 @@ LastFM.prototype._xhr = function(method, params, callback) {
 
     xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded; charset=UTF-8");
     // The cache is a lie!
-    xhr.setRequestHeader("If-Modified-Since", new Date(0));
+    xhr.setRequestHeader("If-Modified-Since", "Thu, 01 Jun 1970 00:00:00 GMT");
     xhr.setRequestHeader("Pragma", "no-cache");
     xhr.send(_data || null);
 };


### PR DESCRIPTION
In my Japanese environment, new Date(0).toString is "Thu Jan 01 1970
09:00:00 GMT+0900 (東京 (標準時))" and error occurred. I fix it.
