### PR TITLE
Moves to or opens Google Play on Last.fm authentication.

### DIFF
--- a/html/lastfm_callback.html
+++ b/html/lastfm_callback.html
@@ -4,4 +4,5 @@
  Copyright (c) 2011 Alexey Savartsov <asavartsov@gmail.com>
  Licensed under the MIT license
 -->
+<script src="../js/util.js"></script>
 <script src="../js/lastfm_callback.js"></script>

--- a/js/lastfm_callback.js
+++ b/js/lastfm_callback.js
@@ -10,6 +10,9 @@ function _url_param(name, url) {
 }
 
 chrome.runtime.getBackgroundPage(function(background) {
-    location.href = "http://last.fm/";
     background.get_lastfm_session(_url_param("token", location.search));
+    open_play_tab();
+	setTimeout(function() {
+		window.close();
+	}, 100);
 });

--- a/js/lastfm_callback.js
+++ b/js/lastfm_callback.js
@@ -12,7 +12,7 @@ function _url_param(name, url) {
 chrome.runtime.getBackgroundPage(function(background) {
     background.get_lastfm_session(_url_param("token", location.search));
     open_play_tab();
-	setTimeout(function() {
-		window.close();
-	}, 100);
+    setTimeout(function() {
+        window.close();
+    }, 100);
 });


### PR DESCRIPTION
Hey!

This small change reconsiders the user flow when authenticating against Last.fm. Instead of being taken to the Last.fm home page, the update takes them straight to the Google Play tab (either by find or opening a new one) and closes the callback tab.

This could be considered something to sit as an extension option but I can't imagine it's likely the user would investigate the extension options before authenticating against Last.fm.
