### PR TITLE
Fix YtMusic is_playing detection - check browser tab title instead of…

### DIFF
--- a/js/ytm_contentscript.js
+++ b/js/ytm_contentscript.js
@@ -48,7 +48,9 @@ YtMusicParser.prototype._get_has_song = function() {
  * @return true if song is playing, false if song is paused
  */
 YtMusicParser.prototype._get_is_playing = function() {
-    return play_btn = $("#play-pause-button").attr("title") === "Pause";
+    // YT app prepends current song's name to the tab title
+    var songTitle = this._get_song_title()
+    return songTitle.length > 0 && window.document.title.startsWith(songTitle)
 };
 
 /**


### PR DESCRIPTION
https://github.com/newgiin/cloudplayer-scrobbler/issues/45

After some debugging, I found out playing detection was based on the play button's title:
`.attr("title") === "Pause"`
It turns out the title is translated into the user's locale, so it's not "Pause" if the user's default language is not English.

When compared both button states (playing and paused) unfortunately the only difference is in the SVG icon path, no change in CSS classes etc. I didn't want to hardcode that but I noticed YT prepends browser tab title with current song's name when it's playing, so it seems this is the easiest way how to detect this.